### PR TITLE
feat: add onManifestCreated hook & no emit option

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![Maintainability](https://api.codeclimate.com/v1/badges/b393ef93cb69397b2738/maintainability)](https://codeclimate.com/github/qiwi/module-federation-manifest-plugin/maintainability)
 [![Test Coverage](https://api.codeclimate.com/v1/badges/b393ef93cb69397b2738/test_coverage)](https://codeclimate.com/github/qiwi/module-federation-manifest-plugin/test_coverage)
 [![npm (tag)](https://img.shields.io/npm/v/@qiwi/module-federation-manifest-plugin/latest.svg)](https://www.npmjs.com/package/@qiwi/module-federation-manifest-plugin)
+
 > Webpack plugin to generate manifest about module federation: shared, exposed, remote modules
 
 ### Install
@@ -38,6 +39,22 @@ export const config: webpack.Configuration = {
 
 You can find schema description [here](https://github.com/qiwi/module-federation-manifest-plugin/blob/main/src/main/ts/schema.ts) and real examples in [tests](https://github.com/qiwi/module-federation-manifest-plugin/blob/main/src/test/ts/e2e.spec.ts)
 
+## API
+
+### Hooks
+
+#### onManifestCreated
+
+Invokes after manifest created, but not emitted
+
+```javascript
+compiler.hooks.compilation.tap('MyPlugin', (compilation) => {
+  ModuleFederationManifestPlugin.getHooks(compilation).onManifestCreated.tap('MyPlugin', (manifest) => {
+    console.log(manifest)
+  })
+})
+```
 
 ## License
+
 [MIT](./LICENSE)

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "updeps": "npm_config_yes=true npx npm-upgrade"
   },
   "dependencies": {
+    "tapable": "^2.2.1",
     "tslib": "^2.4.0"
   },
   "devDependencies": {

--- a/src/main/ts/hooks.ts
+++ b/src/main/ts/hooks.ts
@@ -1,0 +1,6 @@
+import type { ModuleFederationManifest } from './schema'
+import type tapable from 'tapable'
+
+export interface Hooks {
+  onManifestCreated: tapable.AsyncSeriesHook<[ModuleFederationManifest]>
+}

--- a/src/main/ts/plugin.ts
+++ b/src/main/ts/plugin.ts
@@ -14,7 +14,7 @@ import {
 type ModuleFederationPluginOptions = ConstructorParameters<typeof webpack.container.ModuleFederationPlugin>[0]
 
 export interface ModuleFederationManifestPluginOptions {
-  filename: string
+  filename?: string
 }
 
 const undefinedOrNotEmptyObject = <T extends {}>(obj: T): T | undefined => {
@@ -145,8 +145,11 @@ export class ModuleFederationManifestPlugin {
   }
 
   private emitManifestAsset(compilation: webpack.Compilation, manifest: ModuleFederationManifest) {
-    const manifestJson = JSON.stringify(manifest)
-    const source = new webpack.sources.RawSource(Buffer.from(manifestJson))
+    if (!this.options.filename) {
+      return
+    }
+
+    const source = new webpack.sources.RawSource(JSON.stringify(manifest))
     compilation.emitAsset(this.options.filename, source)
   }
 

--- a/src/test/fixtures/multiple-package-same-versions/webpack.config.ts
+++ b/src/test/fixtures/multiple-package-same-versions/webpack.config.ts
@@ -12,6 +12,7 @@ export const config: webpack.Configuration = {
   output: {
     path: path.join(__dirname, 'build'),
     filename: 'bundle.js',
+    clean: true,
   },
   plugins: [
     new webpack.container.ModuleFederationPlugin({

--- a/src/test/fixtures/multiple-package-versions/webpack.config.ts
+++ b/src/test/fixtures/multiple-package-versions/webpack.config.ts
@@ -12,6 +12,7 @@ export const config: webpack.Configuration = {
   output: {
     path: path.join(__dirname, 'build'),
     filename: 'bundle.js',
+    clean: true,
   },
   plugins: [
     new webpack.container.ModuleFederationPlugin({

--- a/src/test/fixtures/real-world/bootstrap.js
+++ b/src/test/fixtures/real-world/bootstrap.js
@@ -1,0 +1,7 @@
+import { render } from 'react-dom'
+import { createElement } from 'react'
+import { Button } from 'ui-kit'
+import remoteApp from 'remote1/app'
+
+remoteApp()
+render(createElement(Button()))

--- a/src/test/fixtures/real-world/export.js
+++ b/src/test/fixtures/real-world/export.js
@@ -1,0 +1,1 @@
+export const VALUE = 'value'

--- a/src/test/fixtures/real-world/index.js
+++ b/src/test/fixtures/real-world/index.js
@@ -1,0 +1,1 @@
+import('./bootstrap')

--- a/src/test/fixtures/real-world/node_modules/react-dom/index.js
+++ b/src/test/fixtures/real-world/node_modules/react-dom/index.js
@@ -1,0 +1,1 @@
+export const render = () => {}

--- a/src/test/fixtures/real-world/node_modules/react-dom/package.json
+++ b/src/test/fixtures/real-world/node_modules/react-dom/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "react-dom",
+  "version": "17.0.2"
+}

--- a/src/test/fixtures/real-world/node_modules/react/index.js
+++ b/src/test/fixtures/real-world/node_modules/react/index.js
@@ -1,0 +1,1 @@
+export const createElement = () => {}

--- a/src/test/fixtures/real-world/node_modules/react/package.json
+++ b/src/test/fixtures/real-world/node_modules/react/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "react",
+  "version": "17.0.2"
+}

--- a/src/test/fixtures/real-world/node_modules/ui-kit/index.js
+++ b/src/test/fixtures/real-world/node_modules/ui-kit/index.js
@@ -1,0 +1,3 @@
+import {createElement} from 'react'
+
+export const Button = () => createElement()

--- a/src/test/fixtures/real-world/node_modules/ui-kit/package.json
+++ b/src/test/fixtures/real-world/node_modules/ui-kit/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "ui-kit",
+  "version": "1.0.0",
+  "peerDependencies": {
+    "react": ">=16.0.0"
+  }
+}

--- a/src/test/fixtures/real-world/package.json
+++ b/src/test/fixtures/real-world/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "real-world",
+  "private": true,
+  "dependencies": {
+    "react": "^17.0.2",
+    "react-dom": "^17.0.2",
+    "ui-kit": "^1.0.0"
+  }
+}

--- a/src/test/fixtures/real-world/webpack.config.ts
+++ b/src/test/fixtures/real-world/webpack.config.ts
@@ -12,6 +12,7 @@ export const config: webpack.Configuration = {
   output: {
     path: path.join(__dirname, 'build'),
     filename: '[name].[contenthash].js',
+    clean: true,
   },
   plugins: [
     new webpack.container.ModuleFederationPlugin({

--- a/src/test/fixtures/real-world/webpack.config.ts
+++ b/src/test/fixtures/real-world/webpack.config.ts
@@ -1,0 +1,39 @@
+import path from 'path'
+import webpack from 'webpack'
+import { ModuleFederationManifestPlugin } from '../../../main/ts'
+
+export const config: webpack.Configuration = {
+  stats: 'normal',
+  devtool: false,
+  entry: path.join(__dirname, 'index.js'),
+  optimization: {
+    minimize: false,
+  },
+  output: {
+    path: path.join(__dirname, 'build'),
+    filename: '[name].[contenthash].js',
+  },
+  plugins: [
+    new webpack.container.ModuleFederationPlugin({
+      name: 'container',
+      filename: 'entry.js',
+      shared: {
+        react: {
+          requiredVersion: '^17.0.2',
+        },
+        'react-dom': {
+          requiredVersion: '^17.0.2',
+        },
+      },
+      exposes: {
+        export: path.join(__dirname, './export.js'),
+      },
+      remotes: {
+        remote1: `remote1@http://localhost:4000/remoteEntry.js`,
+      },
+    }),
+    new ModuleFederationManifestPlugin({
+      filename: 'manifest.json',
+    }),
+  ],
+}

--- a/src/test/fixtures/remotes-and-exposed-kitchensink/webpack.config.ts
+++ b/src/test/fixtures/remotes-and-exposed-kitchensink/webpack.config.ts
@@ -12,6 +12,7 @@ export const config: webpack.Configuration = {
   output: {
     path: path.join(__dirname, 'build'),
     filename: '[name].[contenthash].js',
+    clean: true,
   },
   plugins: [
     new webpack.container.ModuleFederationPlugin({

--- a/src/test/fixtures/shared-kitchensink/webpack.config.ts
+++ b/src/test/fixtures/shared-kitchensink/webpack.config.ts
@@ -12,6 +12,7 @@ export const config: webpack.Configuration = {
   output: {
     path: path.join(__dirname, 'build'),
     filename: '[name].[contenthash].js',
+    clean: true,
   },
   plugins: [
     new webpack.container.ModuleFederationPlugin({

--- a/src/test/ts/e2e.spec.ts
+++ b/src/test/ts/e2e.spec.ts
@@ -1,5 +1,8 @@
+import { ModuleFederationManifestPlugin } from '../../main/ts'
 import { test } from 'uvu'
-import { buildAndAssert } from './helpers/build-and-assert'
+import { buildAndAssert, buildFixture, getManifestPath } from './helpers/build-and-assert'
+import { expect } from 'earljs'
+import fs from 'node:fs'
 
 test('multiple package versions', async (t) => {
   await buildAndAssert(t, 'multiple-package-versions', {
@@ -87,6 +90,20 @@ test('remotes and exposed kitchensink', async (t) => {
       },
     },
   })
+})
+
+test('should not emit when filename is empty', async () => {
+  const fixtureName = 'real-world'
+
+  await buildFixture('real-world', (config) => {
+    const cfgCopy = { ...config }
+    cfgCopy.plugins = cfgCopy.plugins!.filter((plugin) => plugin.constructor.name !== 'ModuleFederationManifestPlugin')
+    cfgCopy.plugins.push(new ModuleFederationManifestPlugin({}))
+    return cfgCopy
+  })
+  const manifestPath = getManifestPath(fixtureName)
+
+  expect(fs.existsSync(manifestPath)).toEqual(false)
 })
 
 test.run()

--- a/src/test/ts/helpers/build-and-assert.ts
+++ b/src/test/ts/helpers/build-and-assert.ts
@@ -15,10 +15,12 @@ const runCompilerAsync = (compiler: webpack.Compiler): Promise<webpack.Stats> =>
 
 const fixturesDir = path.join(__dirname, '../..', 'fixtures')
 
+export const getManifestPath = (fixtureName: string): string => {
+  return path.join(fixturesDir, fixtureName, 'build', 'manifest.json')
+}
+
 const getManifest = async (fixtureName: string): Promise<unknown> => {
-  return await fs
-    .readFile(path.join(fixturesDir, fixtureName, 'build', 'manifest.json'), 'utf-8')
-    .then((value) => JSON.parse(value))
+  return await fs.readFile(getManifestPath(fixtureName), 'utf-8').then((value) => JSON.parse(value))
 }
 
 export const buildFixture = async (

--- a/src/test/ts/hooks.spec.ts
+++ b/src/test/ts/hooks.spec.ts
@@ -1,0 +1,61 @@
+import { ModuleFederationManifestPlugin, ModuleFederationManifest } from '../../main/ts'
+import { test } from 'uvu'
+import type webpack from 'webpack'
+import { buildFixture } from './helpers/build-and-assert'
+import { expect, mockFn } from 'earljs'
+
+test('should call onManifestCreated hook with manifest as argument', async () => {
+  const onManifestCreatedCallback = mockFn<(manifest: ModuleFederationManifest) => any>()
+  onManifestCreatedCallback.resolvesToOnce(undefined)
+
+  const testPlugin = {
+    apply: function (compiler: webpack.Compiler) {
+      compiler.hooks.compilation.tap('TestPlugin', (compilation) => {
+        ModuleFederationManifestPlugin.getHooks(compilation).onManifestCreated.tap(
+          'TestPlugin',
+          onManifestCreatedCallback,
+        )
+      })
+    },
+  }
+
+  await buildFixture('real-world', (config) => {
+    config.plugins = config.plugins || []
+    config.plugins.push(testPlugin)
+    return config
+  })
+
+  expect(onManifestCreatedCallback).toHaveBeenCalledExactlyWith([
+    [
+      {
+        name: 'container',
+        publicPath: 'auto',
+        entry: {
+          path: 'entry.js',
+        },
+        exposes: {
+          export: {
+            name: undefined,
+          },
+        },
+        provides: {
+          react: [{ version: '17.0.2', shareScope: 'default' }],
+          'react-dom': [{ version: '17.0.2', shareScope: 'default' }],
+        },
+        remotes: {
+          remote1: {
+            modules: ['app'],
+          },
+        },
+        consumes: {
+          react: [{ version: '^17.0.2', shareScope: 'default', singleton: false, strictVersion: true, eager: false }],
+          'react-dom': [
+            { version: '^17.0.2', shareScope: 'default', singleton: false, strictVersion: true, eager: false },
+          ],
+        },
+      },
+    ],
+  ])
+})
+
+test.run()

--- a/src/test/ts/hooks.spec.ts
+++ b/src/test/ts/hooks.spec.ts
@@ -20,8 +20,9 @@ test('should call onManifestCreated hook with manifest as argument', async () =>
   }
 
   await buildFixture('real-world', (config) => {
-    config.plugins = config.plugins || []
-    config.plugins.push(testPlugin)
+    const cfgCopy = { ...config }
+    cfgCopy.plugins = cfgCopy.plugins || []
+    cfgCopy.plugins.push(testPlugin)
     return config
   })
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3283,7 +3283,7 @@ supports-preserve-symlinks-flag@^1.0.0:
   resolved "https://registry.yarnpkg.com/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz#6eda4bd344a3c94aea376d4cc31bc77311039e09"
   integrity sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==
 
-tapable@^2.1.1, tapable@^2.2.0:
+tapable@^2.1.1, tapable@^2.2.0, tapable@^2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/tapable/-/tapable-2.2.1.tgz#1967a73ef4060a82f12ab96af86d52fdb76eeca0"
   integrity sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==


### PR DESCRIPTION
Adds onManifestCreated hook which can be used to use manifest in another plugins
When filename is empty, then manifest won't be emitted

## Changes
<!-- What exactly you have changed, and how it works now -->

- [x] New code is covered by tests
- [x] All the changes are mentioned in docs (readme.md)
